### PR TITLE
fix Dyn32::SIZE

### DIFF
--- a/src/dynamic/elf32.rs
+++ b/src/dynamic/elf32.rs
@@ -11,7 +11,7 @@ pub struct Dyn32 {
 }
 
 impl Dyn32 {
-    pub const SIZE: usize = 0x10;
+    pub const SIZE: usize = 0x8;
     pub fn get_type(&self) -> dynamic::EntryType {
         dynamic::EntryType::from(self.d_tag as i64)
     }


### PR DESCRIPTION
```rust
#[derive(Default, Debug, Clone, Hash, PartialOrd, Ord, PartialEq, Eq, Serialize, Deserialize)]
#[repr(C)]
pub struct Dyn32 {
    /// dynamic entry type
    pub d_tag: Elf32Sword, // i32
    /// value
    pub d_un: Elf32Word, // u32
}
```

sizeof(i32) + sizeof(u32) = 0x8